### PR TITLE
SONICDC-370 show interface status in admin mode take more time

### DIFF
--- a/dbmvtx9180/sonic_platform/component.py
+++ b/dbmvtx9180/sonic_platform/component.py
@@ -59,7 +59,7 @@ class Component(ComponentBase):
     def _get_fpga_version(self):
         # Retrieves the CPLD firmware version
         fpga_version = dict()
-        cmdstatus, fpga_fw_version = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(FPGA_FW_VERSION_REG_OFFSET)])
+        cmdstatus, fpga_fw_version = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(FPGA_FW_VERSION_REG_OFFSET)])
         if cmdstatus != 0:
             print("Error reading reg {}".format(hex(reg_offset)))
             fpga_version["SysFPGA"] = 'N/A'

--- a/dbmvtx9180/sonic_platform/fan.py
+++ b/dbmvtx9180/sonic_platform/fan.py
@@ -132,13 +132,13 @@ class Fan(PddfFan):
             An integer, speed of fan in RPM
         """
 
-        cmdstatus, rpm_0 = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
+        cmdstatus, rpm_0 = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
         if cmdstatus != 0:
             print("Error reading reg {}".format(hex(reg_offset)))
             return 0
 
         reg_offset = reg_offset+1
-        cmdstatus, rpm_1 = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
+        cmdstatus, rpm_1 = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
         if cmdstatus != 0:
             print("Error reading reg {}".format(hex(reg_offset)))
             return 0

--- a/dbmvtx9180/sonic_platform/thermal.py
+++ b/dbmvtx9180/sonic_platform/thermal.py
@@ -72,7 +72,7 @@ class Thermal(PddfThermal):
             A float, temperature value in celcius
         """
 
-        cmdstatus, temperature = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
+        cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
         if cmdstatus != 0:
             print("Error reading reg {}".format(hex(reg_offset)))
             return 0
@@ -119,7 +119,7 @@ class Thermal(PddfThermal):
         if self.is_psu_thermal:
             return notimplementederror
         else:
-            cmdstatus, temperature = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+            cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
             if cmdstatus != 0:
                 print("Error reading reg {}".format(hex(reg_offset)))
                 return 0
@@ -137,7 +137,7 @@ class Thermal(PddfThermal):
         if self.is_psu_thermal:
             return notimplementederror
         else:
-            cmdstatus, temperature = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+            cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
             if cmdstatus != 0:
                 print("Error reading reg {}".format(hex(reg_offset)))
                 return 0

--- a/dbmvtx9180/sonic_platform/thermal.py
+++ b/dbmvtx9180/sonic_platform/thermal.py
@@ -26,6 +26,11 @@ class Thermal(PddfThermal):
         self.minimum_thermal = self.get_temperature()
         self.maximum_thermal = self.get_temperature()
 
+    def isDockerEnv(self):
+        num_docker = open('/proc/self/cgroup', 'r').read().count(":/docker")
+        if num_docker > 0:
+            return True
+
     def get_presence(self):
         """
         Retrieves the presence of the thermal
@@ -72,7 +77,13 @@ class Thermal(PddfThermal):
             A float, temperature value in celcius
         """
 
-        cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
+        cmdstatus = 0
+        temperature = ""
+        if self.isDockerEnv():
+            cmdstatus, temperature = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
+        else:
+            cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(reg_offset)])
+
         if cmdstatus != 0:
             print("Error reading reg {}".format(hex(reg_offset)))
             return 0
@@ -119,7 +130,14 @@ class Thermal(PddfThermal):
         if self.is_psu_thermal:
             return notimplementederror
         else:
-            cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+
+            cmdstatus = 0
+            temperature = ""
+            if self.isDockerEnv():
+                cmdstatus, temperature = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+            else:
+                cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+
             if cmdstatus != 0:
                 print("Error reading reg {}".format(hex(reg_offset)))
                 return 0
@@ -137,7 +155,13 @@ class Thermal(PddfThermal):
         if self.is_psu_thermal:
             return notimplementederror
         else:
-            cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+            cmdstatus = 0
+            temperature = ""
+            if self.isDockerEnv():
+                cmdstatus, temperature = getstatusoutput_noshell(['i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+            else:
+                cmdstatus, temperature = getstatusoutput_noshell(['sudo', 'i2cget', '-f', '-y', str(FPGA_I2C_BUS_NUM), str(FPGA_DEV_ADDR), str(0x50)])
+
             if cmdstatus != 0:
                 print("Error reading reg {}".format(hex(reg_offset)))
                 return 0


### PR DESCRIPTION
SONICDC-370: show interface status in admin mode take more time
Issue:
show interface status CLI is taking longer then expected.

RCA:
In TL10 DB platform, plugins implementation provides default
sudo permission for i2cget command. Due to which it was taking
long time.

Fix:
Logic has been implemented to identify the current running
environment. sudo permission required only when plugins are
being accessed from outside the docker environment.