### PR TITLE
dbmvtx9180: remove i2c-ismt from module load conf

### DIFF
--- a/dbmvtx9180/cfg/dbmvtx9180.conf
+++ b/dbmvtx9180/cfg/dbmvtx9180.conf
@@ -6,7 +6,6 @@ i2c-dev
 at24
 i2c-i801
 i2c-isch
-i2c-ismt
 i2c-mux
 i2c-smbus
 i2c-mux-gpio


### PR DESCRIPTION
dbmvtx9180: remove i2c-ismt from module load conf